### PR TITLE
feat(config): add the ability to pass vite config as plugin args

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,27 @@ export default {
 };
 ```
 
-Use a [vite config] to make the build more complex, see the examples.
+Use a [vite config] to make the build more complex. 
+This can be done via a config file or directly passing it to the plugin.
+For example, to enable react support without a vite config, you can use the following config:
+```javascript
+// web-test-runner.config.js
+import { vitePlugin } from './src/index.js';
+
+import reactRefresh from '@vitejs/plugin-react-refresh';
+
+export default {
+	files: [ 'test/**/*.test.ts', 'test/**/*.test.jsx' ],
+	plugins: [
+		vitePlugin({
+			plugins: [ reactRefresh() ],
+		}),
+	],
+};
+```
+
 
 [@web/test-runner]: https://modern-web.dev/docs/test-runner/overview/
 [@web/dev-server]: https://modern-web.dev/docs/dev-server/overview/
 [vite-web-test-runner]: https://github.com/material-svelte/vite-web-test-runner-plugin/
 [vite config]: https://vitejs.dev/config/
-
-Pass specific config to the vite dev server:
-```javascript
-// web-test-runner.config.js
-import { vitePlugin } from '@remcovaes/web-test-runner-vite-plugin';
-
-export default {
-	files: 'src/**/*.test.ts',
-	plugins: [
-		vitePlugin({
-            configFile: "/path/to/my/vite.config.ts",
-            root: '/path/to/my/project/root',
-			// ...
-        }),
-	],
-};
-```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ Use a [vite config] to make the build more complex, see the examples.
 [@web/dev-server]: https://modern-web.dev/docs/dev-server/overview/
 [vite-web-test-runner]: https://github.com/material-svelte/vite-web-test-runner-plugin/
 [vite config]: https://vitejs.dev/config/
+
+Pass specific config to the vite dev server:
+```javascript
+// web-test-runner.config.js
+import { vitePlugin } from '@remcovaes/web-test-runner-vite-plugin';
+
+export default {
+	files: 'src/**/*.test.ts',
+	plugins: [
+		vitePlugin({
+            configFile: "/path/to/my/vite.config.ts",
+            root: '/path/to/my/project/root',
+			// ...
+        }),
+	],
+};
+```

--- a/src/web-test-runner-vite.js
+++ b/src/web-test-runner-vite.js
@@ -1,12 +1,12 @@
 import { existsSync } from 'node:fs';
 
-import { createServer } from 'vite';
+import { createServer, mergeConfig } from "vite";
 
 import { callWithFileNames } from './call-with-file-names.js';
 import { markExternal } from './mark-external.js';
 import { proxy } from './proxy.js';
 
-export const vitePlugin = () => {
+export const vitePlugin = (config = {}) => {
 	let viteServer;
 	
 	return {
@@ -28,13 +28,15 @@ export const vitePlugin = () => {
 				]),
 			];
 			
-			viteServer = await createServer({
-				clearScreen: false,
-				plugins,
-				/* Disable hmr in favor of the @web/test-runner to take care of
-				 * restarts. */
-				server: { hmr: false },
-			});
+			viteServer = await createServer(
+				mergeConfig(config, {
+					clearScreen: false,
+					plugins,
+					/* Disable hmr in favor of the @web/test-runner to take care of
+					* restarts. */
+					server: { hmr: false },
+				})
+		    	);
 			await viteServer.listen();
 			
 			const vitePort = viteServer.config.server.port;

--- a/src/web-test-runner-vite.js
+++ b/src/web-test-runner-vite.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 
-import { createServer, mergeConfig } from "vite";
+import { createServer, mergeConfig } from 'vite';
 
 import { callWithFileNames } from './call-with-file-names.js';
 import { markExternal } from './mark-external.js';
@@ -36,7 +36,7 @@ export const vitePlugin = (config = {}) => {
 					* restarts. */
 					server: { hmr: false },
 				})
-		    	);
+			);
 			await viteServer.listen();
 			
 			const vitePort = viteServer.config.server.port;

--- a/src/web-test-runner-vite.js
+++ b/src/web-test-runner-vite.js
@@ -6,6 +6,9 @@ import { callWithFileNames } from './call-with-file-names.js';
 import { markExternal } from './mark-external.js';
 import { proxy } from './proxy.js';
 
+/**
+ * @param config {import('vite').UserConfig}
+ */
 export const vitePlugin = (config = {}) => {
 	let viteServer;
 	

--- a/test/App.jsx
+++ b/test/App.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="App">
+        <button onClick={() => console.log('not used')}>
+          count is: {count}
+        </button>
+        <button data-testid="button" onClick={() => setCount((count) => count + 1)}>
+          count is: {count}
+        </button>
+    </div>
+  )
+}
+
+export default App

--- a/test/App.test.jsx
+++ b/test/App.test.jsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import App from './App';
+
+describe('<App>', () => {
+  it('works when adding the plugin via the @web/test-runner config', async () => {
+     render(<App/>);
+    const button = document.querySelector("[data-testid=button]");
+    button.click()
+    await Promise.resolve();
+    expect(button.textContent).to.contain('1');
+  });
+});

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,8 +1,11 @@
 import { vitePlugin } from './src/index.js';
+import reactRefresh from '@vitejs/plugin-react-refresh';
 
 export default {
-  files: 'test/**/*.test.ts',
+  files: [ 'test/**/*.test.ts', 'test/**/*.test.jsx' ],
   plugins: [
-    vitePlugin(),
+    vitePlugin({
+      plugins: [ reactRefresh() ],
+    }),
   ],
 };


### PR DESCRIPTION
Hello @remcovaes,

First of all thanks for maintaining this package: it is very useful. 🙏

In my current project we are using it in a complex workspace setup where we abstract away test configurations from individual packages into a shared one. We need more granular control on the config picked up by the vite dev-server and therefore we are using a monkey-patched version of your package.
I believe what we have patched could be useful also to somebody else therefore this PR.
Additionally it would be nice to simply remove a dedicated patched version from our project and simply use your package as a dependency.