### PR TITLE
feat: allow https in proxy

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -1,7 +1,9 @@
 import http from 'node:http';
+import https from 'node:https';
 
 const get = url => new Promise((resolve, reject) => {
-	const request = http.get(url, (response) => {
+	const getByProtocol = url.startsWith('https') ? https.get : http.get;
+	const request = getByProtocol(url, (response) => {
 		const buffers = [];
 		let bufferLen = 0;
 


### PR DESCRIPTION
Using a local dev server with ssl no more results in "unsupported protocol" errors.

When using ssl locally (e.g. by [`vite-plugin-mkcert`](https://github.com/liuweiGL/vite-plugin-mkcert#readme)), then node throws:
```bash
TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
```
Caused by the minimal node proxy, which is http only.

This PR simply checks the requesting URL if it uses `https` and switches usage to the `get` function of nodes `https` module instead.